### PR TITLE
Small change to permit control of doing a yum update -y

### DIFF
--- a/rhel7.2-ansible/Vagrantfile
+++ b/rhel7.2-ansible/Vagrantfile
@@ -3,6 +3,7 @@ Vagrant.configure(2) do |config|
   config.vm.box = "rhel72x64"
   
   config.vm.provision :ansible do |ansible|
-    ansible.playbook  = "provisioning/playbook.yml"
+    ansible.playbook   = "provisioning/playbook.yml"
+    ansible.extra_vars = { update: false }
   end
 end

--- a/rhel7.2-ansible/provisioning/playbook.yml
+++ b/rhel7.2-ansible/provisioning/playbook.yml
@@ -1,6 +1,8 @@
 ---
 - hosts: all
   become: true
+  vars:
+    update: false
   tasks:
     - name:  Register and auto-subscribe to available content
       redhat_subscription:
@@ -11,6 +13,7 @@
 
     - name: Upgrade all packages
       command: yum update -y
+      when: update
 
     - name: Ensure NTP is Installed and the latest version
       yum:


### PR DESCRIPTION
Here's a small change to the Vagrantfile and playbook that permits control of the 'update all packages' step. This is also a small example of how you can tie 'flexible control' between Vagrant and Ansible. By default it **won't** update with this setting (see extra_vars in Vagrantfile)

<img width="682" alt="screen shot 2016-01-04 at 20 57 20" src="https://cloud.githubusercontent.com/assets/329022/12100316/20d7034e-b326-11e5-8c3f-d1d3c03a0bed.png">
